### PR TITLE
マウスと弾二種

### DIFF
--- a/Assets/Script/Baramaki.cs
+++ b/Assets/Script/Baramaki.cs
@@ -1,0 +1,44 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Baramaki : MonoBehaviour
+{
+    [SerializeField] private GameObject bulletPrefab;
+    [SerializeField] private float makeTime;
+    private float waitTime;
+    [SerializeField] private float lagTime;
+    [SerializeField] private float bulletX;
+    [SerializeField] private float bulletY;
+    [SerializeField] private float bulletZ;
+    private Vector3 posi;
+    private int a;
+    private float ranX;
+    // Start is called before the first frame update
+    void Start()
+    {
+        waitTime += lagTime;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        posi = this.transform.position;
+
+        if (waitTime < makeTime)
+        {
+            waitTime = waitTime + Time.deltaTime;
+        }
+        else
+        {
+            a = 0;
+            while (a < 8)
+            {
+                ranX = Random.Range(bulletX * -1, bulletX);
+                Instantiate(bulletPrefab, new Vector3(ranX + posi.x, bulletY + posi.y, bulletZ + posi.z), bulletPrefab.transform.rotation);
+                a++;
+            }
+            waitTime = 0;
+        }
+    }
+}

--- a/Assets/Script/Baramaki.cs.meta
+++ b/Assets/Script/Baramaki.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c93c6969ffb4a54fa4f7f4eb1b3cd0a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/E3way.cs
+++ b/Assets/Script/E3way.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class E3way : MonoBehaviour
+{
+    [SerializeField] private GameObject bulletPrefab1;
+    [SerializeField] private GameObject bulletPrefab2;
+    [SerializeField] private GameObject bulletPrefab3;
+    [SerializeField] private float makeTime;
+    private float waitTime;
+    [SerializeField] private float lagTime;
+    private Vector3 posi;
+    // Start is called before the first frame update
+    void Start()
+    {
+        waitTime += lagTime;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        posi = this.transform.position;
+
+        if (waitTime < makeTime)
+        {
+            waitTime = waitTime + Time.deltaTime;
+        }
+        else
+        {
+            Instantiate(bulletPrefab1, new Vector3(posi.x, posi.y, posi.z), bulletPrefab1.transform.rotation);
+            Instantiate(bulletPrefab2, new Vector3(posi.x, posi.y, posi.z), bulletPrefab2.transform.rotation);
+            Instantiate(bulletPrefab3, new Vector3(posi.x, posi.y, posi.z), bulletPrefab3.transform.rotation);
+            waitTime = 0;
+        }
+    }
+}

--- a/Assets/Script/E3way.cs.meta
+++ b/Assets/Script/E3way.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20f87700c50711b4e99c846c67833a97
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/MouseHoming.cs
+++ b/Assets/Script/MouseHoming.cs
@@ -1,0 +1,23 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class NewBehaviourScript : MonoBehaviour
+{
+    private Vector3 mouse;
+    private Vector3 target;
+    private int speed;
+    // Start is called before the first frame update
+    void Start()
+    {
+        speed = 80;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        mouse = Input.mousePosition;
+        target = Camera.main.ScreenToWorldPoint(new Vector3(mouse.x, mouse.y, 10));
+        transform.position += transform.forward * speed;
+    }
+}

--- a/Assets/Script/MouseHoming.cs.meta
+++ b/Assets/Script/MouseHoming.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ce15320adf61bfd48ad8328ba4646d42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
AssetsのScriptにMouseHoming,Baramaki,E3wayの三つのスクリプトを追加。
MouseHomingは導入したマテリアルが一定速度でマウスカーソルについていくようにする。
Baramaki,E3wayは座標の微調整を行い、発射する弾(速度,ライフタイム等を設定したもの)を入れれば動作する。